### PR TITLE
(kill_after_update) Kill the client after updating it

### DIFF
--- a/pulse_xmpp_agent/agentxmpp.py
+++ b/pulse_xmpp_agent/agentxmpp.py
@@ -2302,6 +2302,8 @@ class MUCBot(sleekxmpp.ClientXMPP):
             logger.error("installed agent version %s (indefinie operation). We will not switch to new agent."%(versiondata))
             logger.error("return code is : %s"%(result['code']))
 
+        return result['code']
+
     def checkinstallagent(self):
         if self.config.updating == 1:
             if os.path.isfile(os.path.join(self.pathagent, "BOOL_UPDATE_AGENT")):
@@ -2313,7 +2315,11 @@ class MUCBot(sleekxmpp.ClientXMPP):
                     logger.debug("Fingerprint of Master Image: %s" % self.descriptor_master['fingerprint'] )
                     if Update_Remote_Agenttest.get_fingerprint_agent_base() != Update_Remote_Img.get_fingerprint_agent_base() and \
                     Update_Remote_Img.get_fingerprint_agent_base() ==  self.descriptor_master['fingerprint']:
-                        self.reinstall_agent()
+                        reinstalled_state = self.reinstall_agent()
+
+                    if reinstalled_state == 1:
+                        logger.info("In order to use the new libraries we will restart the agent")
+                        utils.killMedullaAgent()
                 else:
                     logger.warning("ask update but descriptor_agent base missing.")
 

--- a/pulse_xmpp_agent/lib/utils.py
+++ b/pulse_xmpp_agent/lib/utils.py
@@ -1006,6 +1006,18 @@ def windowsservice(name, action):
             pass
 
 
+def killMedullaAgent():
+    """
+        This function is used to kill the Medulla Agent.
+        It is used mainly after an autoupdate, to ensure we use the last version.
+
+        It uses the pid of the agent, which is stored in the `pidagent` file.
+    """
+    pidfile = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "INFOSTMP", "pidagent")
+    pid = int(utils.file_get_contents(pidfile).strip())
+    os.kill(pid, signal.SIGTERM)
+
+
 def methodservice():
     import pythoncom
     import wmi


### PR DESCRIPTION
When a library ( from utils.py for exemple ) is updated medulla is not completly restarted so it does not use the new functions or modified functions.

Now, when the agent is updated we completly restart it.