### PR TITLE
(cdn) Fix CDN support when deploying bundles

### DIFF
--- a/pulse_xmpp_agent/plugins_common/plugin_applicationdeploymentjson.py
+++ b/pulse_xmpp_agent/plugins_common/plugin_applicationdeploymentjson.py
@@ -27,7 +27,7 @@ if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
 elif sys.platform.startswith('win'):
     import win32net
 
-plugin = {"VERSION": "5.30", "NAME": "applicationdeploymentjson", "VERSIONAGENT": "2.0.0", "TYPE": "all"}
+plugin = {"VERSION": "5.31", "NAME": "applicationdeploymentjson", "VERSIONAGENT": "2.0.0", "TYPE": "all"}
 
 Globaldata = {'port_local': 22}
 logger = logging.getLogger()
@@ -581,11 +581,23 @@ def action(objectxmpp, action, sessionid, data, message, dataerreur):
             if data['transfert'] and \
                 data['methodetransfert'] in ["pullcurl", "pulldirect"]:
                 #pull method download file
+                is_bundle = False
+                if objectxmpp.back_to_deploy:
+                    main_session = next(iter(objectxmpp.back_to_deploy))
+                    bundle_package = objectxmpp.back_to_deploy[main_session]['Dependency'][0]
+                    if ('hash_info' in objectxmpp.back_to_deploy[main_session]['packagelist'][bundle_package]['descriptor']['info'] and objectxmpp.back_to_deploy[main_session]['packagelist'][bundle_package]['descriptor']['info']['hash_info']['url'] != ""):
+                        is_bundle = True
+
+
                 if data['methodetransfert'] in ["pullcurl"]:
-                    if ('hash_info' in data['descriptor']['info'] and data['descriptor']['info']['hash_info']['url'] != ""):
-                        logger.info("----------------------------------------------------")
-                        logger.info("---------------Download file with CDN---------------")
-                        logger.info("----------------------------------------------------")
+                    if (is_bundle or ('hash_info' in data['descriptor']['info'] and data['descriptor']['info']['hash_info']['url'] != "")):
+
+                        logger.debug("----------Download file using CDN----------")
+
+                        if objectxmpp.back_to_deploy:
+                            if not 'hash_info' in data['descriptor']['info']:
+                                data['descriptor']['info']['hash_info'] = objectxmpp.back_to_deploy[main_session]['packagelist'][bundle_package]['descriptor']['info']['hash_info']
+
                         recupfile = recuperefilecdn(datasend,
                                                     objectxmpp,
                                                     sessionid)
@@ -2396,7 +2408,7 @@ def recuperefile(datasend, objectxmpp, ippackage, portpackage, sessionid):
 
 def check_hash(objectxmpp, data):
     hash_type = data['hash']['type']
-    dest = os.path.join(os.environ["ProgramFiles"], "Pulse", "var", "tmp", "packages", data['name'])
+    dest = data['pathpackageonmachine']
     dest += "\\"
     concat_hash = ""
 
@@ -2454,18 +2466,18 @@ def recuperefilecdn(datasend, objectxmpp, sessionid):
     for filepackage in datasend['data']['packagefile']:
         if datasend['data']['methodetransfert'] == "pullcurl":
             dest = os.path.join(datasend['data']['pathpackageonmachine'], filepackage)
-            
+
+            packageUuid = str(datasend['data']['descriptor']['info']['packageUuid'])
+
             if ('localisation_server' in datasend['data']['descriptor']['info'] and datasend['data']['descriptor']['info']['localisation_server'] != ""):
-                urlfile = str(curlurlbase) + str(datasend['data']['descriptor']['info']['localisation_server']) + "/" + str(datasend['data']['name']) + "/" + str(filepackage)
+                urlfile = str(curlurlbase) + str(datasend['data']['descriptor']['info']['localisation_server']) + "/" + packageUuid + "/" + str(filepackage)
             elif ('previous_localisation_server' in datasend['data']['descriptor']['info'] and datasend['data']['descriptor']['info']['previous_localisation_server'] != ""):
-                urlfile = str(curlurlbase) + str(datasend['data']['descriptor']['info']['previous_localisation_server']) + "/" + str(datasend['data']['name']) + "/" + str(filepackage)
-                
+                urlfile = str(curlurlbase) + str(datasend['data']['descriptor']['info']['previous_localisation_server']) + "/" + packageUuid + "/" + str(filepackage)
+
             urlobject = urlparse(urlfile)
             urlfile = urlobject.scheme + '://' + urllib.quote(urlobject.netloc) + urllib.quote(urlobject.path)
             token = datasend['data']['descriptor']['info']['hash_info']['token']
-            logger.info("###################################################")
-            logger.info("URL for downloading package using curl : " + urlfile)
-            logger.info("###################################################")
+            logger.debug("URL for downloading package using curl : " + urlfile)
             try:
                 if 'limit_rate_ko' in datasend['data']['descriptor']['info'] and \
                                 datasend['data']['descriptor']['info']['limit_rate_ko'] != "" and\
@@ -2558,7 +2570,7 @@ def recuperefilecdn(datasend, objectxmpp, sessionid):
                 return False
     _check_hash = check_hash(objectxmpp, datasend['data'])
     if _check_hash != datasend['data']['hash']['global']:
-        shutil.rmtree(os.path.join(os.environ["ProgramFiles"], "Pulse", "var", "tmp", "packages", datasend['data']['name']))
+        shutil.rmtree(datasend['data']['pathpackageonmachine'])
         logger.error("HASH INVALID - ABORT DEPLOYMENT")
         objectxmpp.xmpplog('<span class="log_err">Package delayed : hash invalid</span>',
             type='deploy',

--- a/pulse_xmpp_agent/pluginsrelay/plugin_rsapplicationdeploymentjson.py
+++ b/pulse_xmpp_agent/pluginsrelay/plugin_rsapplicationdeploymentjson.py
@@ -5,17 +5,17 @@
 import json
 import os
 from lib import managepackage
+from lib.utils import file_get_contents
 import logging
-
+import configparser
 
 logger = logging.getLogger()
 DEBUGPULSEPLUGIN = 25
-plugin = {"VERSION" : "2.0", "NAME" : "rsapplicationdeploymentjson", "TYPE" : "relayserver"}
+plugin = {"VERSION" : "2.1", "NAME" : "rsapplicationdeploymentjson", "TYPE" : "relayserver"}
 
 
 
 def action(objectxmpp, action, sessionid, data, message, dataerreur):
-    #logging.getLogger().debug("RECV data message %s\n###############\n"%json.dumps(data, indent=4))
     logging.log(DEBUGPULSEPLUGIN,"plugin %s on %s %s from %s"% (plugin, objectxmpp.config.agenttype, message['to'], message['from']))
     datasend = {
                     'action': action,
@@ -26,9 +26,7 @@ def action(objectxmpp, action, sessionid, data, message, dataerreur):
                 }
 
     logging.getLogger().debug("#################RELAY SERVER#####################")
-    logging.getLogger().debug("##############demande pacquage %s ##############"%(data['deploy']))
-    logging.getLogger().debug("##################################################")
-    #envoy descripteur
+    logging.getLogger().debug("##############ask for package %s ##############"%(data['deploy']))
     try:
         descriptor =  managepackage.managepackage.getdescriptorpackageuuid(data['deploy'])
     except Exception as e:
@@ -43,6 +41,21 @@ def action(objectxmpp, action, sessionid, data, message, dataerreur):
         datasend['data'] ['Dtypequery'] =  "TQ"
         datasend['data'] ['Devent'] = "DEPLOYMENT START"
         datasend['data'] ['name'] = managepackage.managepackage.getnamepackagefromuuidpackage(data['deploy'])
+
+        if ('localisation_server' in datasend['data']['descriptor']['info'] and datasend['data']['descriptor']['info']['localisation_server'] != ""):
+            localisation_server = datasend['data']['descriptor']['info']['localisation_server']
+        elif ('previous_localisation_server' in datasend['data']['descriptor']['info'] and datasend['data']['descriptor']['info']['previous_localisation_server'] != ""):
+            localisation_server = datasend['data']['descriptor']['info']['previous_localisation_server']
+
+        hashFolder = os.path.join("/var", "lib", "pulse2", "packages", "hash", localisation_server)
+
+        config = configparser.ConfigParser()
+        config.read('/etc/pulse-xmpp-agent/applicationdeploymentjson.ini.local')
+        hashing_algo = config.get('parameters', 'cdn_hashing_algo')
+
+        if os.path.exists(os.path.join(hashFolder, data['deploy'] + ".hash")):
+            datasend['data']['hash'] = {'global': file_get_contents(os.path.join(hashFolder, data['deploy'] + ".hash")), 'type': hashing_algo}
+
         objectxmpp.send_message(mto=message['from'],
                                 mbody=json.dumps(datasend),
                                 mtype='chat')


### PR DESCRIPTION
When using CDN we use hashes to know the integrity of the files/programs.

Now we add the hash of every packages/dependancies in the Json files. This allow more security as now we can check every single dependancies and not only the main bundle.