### PR TITLE
(UserInteraction) Add check for respecting the interval and remove se…

### DIFF
--- a/pulse_xmpp_agent/agentxmpp.py
+++ b/pulse_xmpp_agent/agentxmpp.py
@@ -718,7 +718,7 @@ class MUCBot(sleekxmpp.ClientXMPP):
             try:
                 filenamejson = os.path.join(dir_reprise_session, t)
                 detection=t.split('@_@')
-                if len(detection) == 5 and detection[0] == "medulla_protected":
+                if len(detection) == 5 and detection[0] == "medulla_protected" and (timecurrent+60) >= int(time.mktime(time.localtime(float(detection[1])))):
                     with open(filenamejson, 'r') as f:
                         data = json.load(f)
                     datainfo=data['data']
@@ -734,6 +734,7 @@ class MUCBot(sleekxmpp.ClientXMPP):
                                                                                                         slotdep,
                                                                                                         slotend)
                             grafcet(self, data)
+                            os.remove(filenamejson)
                         except:
                             logger.error("\nResumption deploy %s"%(traceback.format_exc()))
                     else:
@@ -746,12 +747,15 @@ class MUCBot(sleekxmpp.ClientXMPP):
                                                                                                     timecurentdatetime)
                             # reinjection for terminate deploy error correctement
                             grafcet(self, data)
+                            os.remove(filenamejson)
                         except:
                             logger.error("\nABORT DEPLOYMENT SHUTDOWN %s"%(traceback.format_exc()))
+                else:
+                    logger.error("We are not in the interval yet")
+                    break
             except:
                 logger.error("reinjection deploy protected\n%s"%(traceback.format_exc()))
-            finally:
-                os.remove(filenamejson)
+                os.rename(filenamejson, os.path.join(os.path.dirname(filenamejson),"error_session_grafcet"+os.path.basename(filenamejson)))
         return
 
     def reinjection_deplot_message_box(self):
@@ -765,7 +769,7 @@ class MUCBot(sleekxmpp.ClientXMPP):
             try:
                 filenamejson = os.path.join(dir_reprise_session, t)
                 detection=t.split('@_@')
-                if len(detection) == 5 and detection[0]=="medulla_messagebox":
+                if len(detection) == 5 and detection[0]=="medulla_messagebox" and (timecurrent+60) >= int(time.mktime(time.localtime(float(detection[1])))):
                     with open(filenamejson, 'r') as f:
                         data = json.load(f)
                     datainfo=data['data']
@@ -774,10 +778,13 @@ class MUCBot(sleekxmpp.ClientXMPP):
                     if (timecurrent+60) >= int(time.mktime(time.gmtime(datainfo['stardate']))) and (timecurrent+60) <= int(time.mktime(time.gmtime(datainfo['enddate']))):
                         # on relance le deployement et on quitte
                         grafcet(self, data)
+                        os.remove(filenamejson)
+                else:
+                    logger.error("We are not in the interval yet")
+                    break
             except:
                 logger.error("reinjection deploy message box\n%s"%(traceback.format_exc()))
-            finally:
-                os.remove(filenamejson)
+                os.rename(filenamejson, os.path.join(os.path.dirname(filenamejson),"error_session_grafcet_"+os.path.basename(filenamejson)))
         return
     ###############################################################
     # syncthing function

--- a/pulse_xmpp_agent/lib/grafcetdeploy.py
+++ b/pulse_xmpp_agent/lib/grafcetdeploy.py
@@ -1275,7 +1275,7 @@ class grafcet:
                 "INFOSTMP",
                 "REPRISE")
         filelistprotected = [ os.path.join(dir_reprise_session, x) for x in os.listdir(dir_reprise_session) \
-                     if os.path.isfile(os.path.join(dir_reprise_session, x)) and x.endswith(self.sessionid)]
+                if os.path.isfile(os.path.join(dir_reprise_session, x)) and x.endswith(self.sessionid) and x.startswith("medulla_protected")]
         for t in filelistprotected:
             if os.path.isfile(t):
                 os.remove(t)


### PR DESCRIPTION
…ssion file only after grafcetdeploy

For each session file on user interaction deployment, we check if the interval is respected after click on 'No' button, we will wait interval time and open it and continue to grafcetdeploy. Before this fix, session file of deployment was delete in any case, and deployment could not work correctly. Now we delete session file only if grafcetdeploy has correctly work.